### PR TITLE
Implement new error handling pattern for scripting

### DIFF
--- a/docgen/module.hbs
+++ b/docgen/module.hbs
@@ -42,10 +42,12 @@
 <div group="{{item.name}}" id="{{item.name}}-{{section.name}}" class="tabcontent" {{#if @first}} style="display: block;" {{else}} style="display: none;" {{/if}}>
 
 {{> ContentPartial content=section.body}}
+
 </div>
 {{/each}}
 
 </div>
 </div>
 </br>
+
 {{/each}}

--- a/talaria/src/scripting.rs
+++ b/talaria/src/scripting.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use bincode::{Decode, Encode};
-use bytesize::Display;
 use rhai::{plugin::*, Scope};
 use serde::{Deserialize, Serialize};
 

--- a/talaria/src/stdlib/error.rs
+++ b/talaria/src/stdlib/error.rs
@@ -7,65 +7,71 @@ use strum_macros::{EnumProperty, IntoStaticStr};
 pub mod error {
     #[derive(Display, Debug, Clone, IntoStaticStr, EnumProperty)]
     pub enum ScriptError {
-        #[strum(props(class = "fs", name = "otherFs"), to_string = "{0}")]
+        #[strum(props(class = "fs", name = "OtherFs"), to_string = "{0}")]
         FsError(String),
 
         #[strum(
-            props(class = "fs", name = "fileNotFound"),
+            props(class = "fs", name = "FileNotFound"),
             to_string = "could not find file at path: \"{file_path}\""
         )]
         FsFileNotFound { file_path: String },
 
         #[strum(
-            props(class = "fs", name = "directoryNotFound"),
+            props(class = "fs", name = "DirectoryNotFound"),
             to_string = "could not find directory at path: \"{path}\""
         )]
         FsDirectoryNotFound { path: String },
 
         #[strum(
-            props(class = "fs", name = "permissionDenied"),
+            props(class = "fs", name = "PermissionDenied"),
             to_string = "user does not have permission to {permission} \"{path}\""
         )]
         FsPermissionDenied { path: String, permission: String },
 
         #[strum(
-            props(class = "fs", name = "filenameTooLong"),
+            props(class = "fs", name = "FilenameTooLong"),
             to_string = "filename \"{filename}\" is too long"
         )]
         FsFilenameTooLong { filename: String },
 
         #[strum(
-            props(class = "fs", name = "isADirectory"),
+            props(class = "fs", name = "IsADirectory"),
             to_string = "path: \"{path}\" is a directory"
         )]
         FsIsADirectory { path: String },
 
         #[strum(
-            props(class = "fs", name = "notADirectory"),
+            props(class = "fs", name = "NotADirectory"),
             to_string = "path: \"{path}\" is not a directory"
         )]
         FsNotADirectory { path: String },
 
         #[strum(
-            props(class = "fs", name = "malformedPath"),
+            props(class = "fs", name = "MalformedPath"),
             to_string = "path: \"{path}\" is malformed"
         )]
         FsMalformedPath { path: String },
 
         #[strum(
-            props(class = "fs", name = "invalidUTF8"),
+            props(class = "fs", name = "InvalidFilename"),
+            to_string = "path: \"{file_path}\" is not a valid filename"
+        )]
+        FsInvalidFilename { file_path: String },
+
+        #[strum(
+            props(class = "fs", name = "InvalidUTF8"),
             to_string = "file: \"{path}\" contains invalid UTF-8"
         )]
         FsInvalidUTF8 { path: String },
 
         #[strum(
-            props(class = "fs", name = "storageDeviceFull"),
+            props(class = "fs", name = "StorageDeviceFull"),
             to_string = "storage device is full"
         )]
         FsStorageFull,
 
         #[strum(
-            props(class = "fs", name = "readOnlyFilesystem"),
+            props(class = "fs", name = "ReadOnlyFilesystem"),
             to_string = "file system is readonly"
         )]
         FsReadOnlyFilesystem,
@@ -97,6 +103,19 @@ pub mod error {
     }
 
     /// Returns the class that this error belongs to
+    //
+    /// # Example
+    ///
+    /// ```typescript
+    /// try {
+    ///     file_contents = fs::read("/home/coal/.config/nvim/")
+    ///     print(file_contents)
+    /// }
+    /// catch (error) {
+    ///     print(error.name);
+    /// }
+    /// ```
+    /// <div>
     #[rhai_fn(get = "class", pure)]
     pub fn get_error_type(error: &mut ScriptError) -> String {
         String::from(match error.get_str("class") {

--- a/talaria/src/stdlib/error.rs
+++ b/talaria/src/stdlib/error.rs
@@ -1,12 +1,45 @@
 use rhai::plugin::*;
-use strum_macros::IntoStaticStr;
+use strum::EnumProperty;
+use strum_macros::{EnumProperty, IntoStaticStr};
 
 #[export_module]
 pub mod error {
-    #[derive(Debug, Clone, IntoStaticStr)]
+    #[derive(Debug, Clone, IntoStaticStr, EnumProperty)]
     pub enum Error {
+        #[strum(props(class = "fs"))]
         FsError(String),
+
+        #[strum(props(class = "fs"))]
+        FsNotFound(String),
+
+        #[strum(props(class = "fs"))]
+        FsPermissionDenied(String),
+
+        #[strum(props(class = "fs"))]
+        FsFilenameTooLong(String),
+
+        #[strum(props(class = "fs"))]
+        FsIsADirectory(String),
+
+        #[strum(props(class = "fs"))]
+        FsNotADirectory(String),
+
+        #[strum(props(class = "fs"))]
+        FsMalformedPath(String),
+
+        #[strum(props(class = "fs"))]
+        FsInvalidUTF8(String),
+
+        #[strum(props(class = "fs"))]
+        FsStorageFull(String),
+
+        #[strum(props(class = "fs"))]
+        FsReadOnlyFilesystem(String),
+
+        #[strum(props(class = "sys"))]
         SysError(String),
+
+        #[strum(props(class = "sys"))]
         SysUnsupportedError(String),
     }
 
@@ -17,6 +50,15 @@ pub mod error {
                 Position::NONE,
             )))
         }
+    }
+
+    /// Returns the class that this error belongs to
+    #[rhai_fn(get = "class", pure)]
+    pub fn get_error_type(error: &mut Error) -> String {
+        String::from(match error.get_str("class") {
+            Some(class) => class,
+            None => "unknown",
+        })
     }
 
     /// Returns a deterministic string that can be matched upon to identify error type

--- a/talaria/src/stdlib/error.rs
+++ b/talaria/src/stdlib/error.rs
@@ -60,7 +60,7 @@ pub mod error {
 
         #[strum(
             props(class = "fs", name = "InvalidUTF8"),
-            to_string = "file: \"{path}\" contains invalid UTF-8"
+            to_string = "file: \"{path}\" contains invalid utf-8"
         )]
         FsInvalidUTF8 { path: String },
 
@@ -93,6 +93,17 @@ pub mod error {
     }
 
     /// Returns a pretty print of the error
+    ///
+    /// # Example
+    ///
+    /// ```typescript
+    /// try {
+    ///     let homework = fs::read("/home/ruby/homework/calc1.mp4");
+    /// }
+    /// catch (error) {
+    ///     print(error.pretty); // `[fs] InvalidUTF8 - file: "/home/ruby/homework/calc1.mp4" contains invalid utf-8`
+    /// }
+    /// ```
     #[rhai_fn(get = "pretty", pure)]
     pub fn get_error_pretty(error: &mut ScriptError) -> String {
         let class = get_error_type(error);
@@ -108,14 +119,17 @@ pub mod error {
     ///
     /// ```typescript
     /// try {
-    ///     file_contents = fs::read("/home/coal/.config/nvim/")
-    ///     print(file_contents)
+    ///     fs::remove("/"); // rm -rf :P
+    ///     sys::reboot();   // it's so joever for them!!!
     /// }
     /// catch (error) {
-    ///     print(error.name);
+    ///     switch(error.class) {
+    ///         "sys" => print("there was some error relating to the sys module"),
+    ///         "fs" => print("there was some error relating to the fs module"),
+    ///         _ => print("some other error occurred"),
+    ///     }
     /// }
     /// ```
-    /// <div>
     #[rhai_fn(get = "class", pure)]
     pub fn get_error_type(error: &mut ScriptError) -> String {
         String::from(match error.get_str("class") {
@@ -125,6 +139,26 @@ pub mod error {
     }
 
     /// Returns a deterministic string that can be matched upon to identify error type
+    ///
+    /// # Example
+    ///
+    /// ```typescript
+    /// try {
+    ///     let seed = fs::read("/home/coal/Important/MoneroSeed");
+    ///     print("all your monero is mine!!");
+    ///     print(seed);
+    /// }
+    /// catch (error) {
+    ///     switch(error.name) {
+    ///         "FileNotFound" => print("the monero seed does not exist"),
+    ///         "PermissionDenied" => print("no permission to read the monero seed"),
+    ///         "IsADirectory" => print("monero seed path is a directory"),
+    ///         "InvalidUTF8" => print("monero seed does not contain valid UTF-8"),
+    ///         "OtherFs" => print("some other filesystem error occurred:" + error.msg),
+    ///         _ => print("some other error occurred"),
+    ///     }
+    /// }
+    /// ```
     #[rhai_fn(get = "name", pure)]
     pub fn get_error_name(error: &mut ScriptError) -> String {
         String::from(match error.get_str("name") {
@@ -133,7 +167,18 @@ pub mod error {
         })
     }
 
-    /// Returns message including both error context and message
+    /// Returns message containing human readable description of the error
+    ///
+    /// # Example
+    ///
+    /// ```typescript
+    /// try {
+    ///     let homework = fs::read("/home/ruby/homework/calc1.mp4");
+    /// }
+    /// catch (error) {
+    ///     print(error.msg); // `file: "/home/ruby/homework/calc1.mp4" contains invalid utf-8`
+    /// }
+    /// ```
     #[rhai_fn(get = "msg", pure)]
     pub fn get_error_msg(error: &mut ScriptError) -> String {
         error.to_string()

--- a/talaria/src/stdlib/fs.rs
+++ b/talaria/src/stdlib/fs.rs
@@ -9,13 +9,23 @@ pub mod fs {
     use crate::stdlib::error::error::ScriptError;
     use rhai::Array;
     use rhai::Dynamic;
-    use std::io::Write;
 
     use crate::stdlib::CastArray;
 
     /// Reads the contents of a file to a string
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` does not exist, or isn't readable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `MalformedPath`
+    /// - `InvalidUTF8`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn read(file_path: &str) -> Result<String, Box<EvalAltResult>> {
         let path = std_Path::new(file_path);
@@ -25,33 +35,40 @@ pub mod fs {
             Err(err) => match err.kind() {
                 std::io::ErrorKind::NotFound => ScriptError::FsFileNotFound {
                     file_path: file_path.into(),
-                }
-                .into(),
+                },
                 std::io::ErrorKind::PermissionDenied => ScriptError::FsPermissionDenied {
                     path: file_path.into(),
                     permission: "read".into(),
-                }
-                .into(),
+                },
                 std::io::ErrorKind::IsADirectory => ScriptError::FsIsADirectory {
                     path: file_path.into(),
-                }
-                .into(),
+                },
                 std::io::ErrorKind::InvalidInput => ScriptError::FsMalformedPath {
                     path: file_path.into(),
-                }
-                .into(),
+                },
                 std::io::ErrorKind::InvalidData => ScriptError::FsInvalidUTF8 {
                     path: file_path.into(),
-                }
-                .into(),
-                _ => ScriptError::FsError(err.to_string()).into(),
-            },
+                },
+                _ => ScriptError::FsError(err.to_string()),
+            }
+            .into(),
         }
     }
 
     /// Read the contents of a file into an array of strings, split on newline characters
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` does not exist, or isn't readable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `MalformedPath`
+    /// - `InvalidUTF8`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn read_lines(file_path: &str) -> Result<Vec<Dynamic>, Box<EvalAltResult>> {
         read(file_path).map(|x| x.split('\n').map(|x| x.to_string().into()).collect())
@@ -62,13 +79,44 @@ pub mod fs {
     /// Will create file and directory recursively if it doesn't exist
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` isn't writable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `ReadOnlyFilesystem`
+    /// - `StorageFull`
+    /// - `InvalidFilename`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn write(file_path: &str, contents: &str) -> Result<(), Box<EvalAltResult>> {
         let path = std_Path::new(file_path);
 
         match std_fs::write(path, contents) {
             Ok(_) => Ok(()),
-            Err(err) => Err(err.to_string().into()),
+            Err(err) => match err.kind() {
+                // we really should never have this unless some sort of race condition occurs
+                std::io::ErrorKind::NotFound => ScriptError::FsFileNotFound {
+                    file_path: file_path.into(),
+                },
+                std::io::ErrorKind::PermissionDenied => ScriptError::FsPermissionDenied {
+                    path: file_path.into(),
+                    permission: "write".into(),
+                },
+                std::io::ErrorKind::IsADirectory => ScriptError::FsIsADirectory {
+                    path: file_path.into(),
+                },
+                std::io::ErrorKind::ReadOnlyFilesystem => ScriptError::FsReadOnlyFilesystem,
+                std::io::ErrorKind::StorageFull => ScriptError::FsStorageFull,
+                std::io::ErrorKind::InvalidFilename => ScriptError::FsInvalidFilename {
+                    file_path: file_path.into(),
+                },
+                _ => ScriptError::FsError(err.to_string()),
+            }
+            .into(),
         }
     }
 
@@ -77,6 +125,18 @@ pub mod fs {
     /// Will create file and directory recursively if it doesn't exist
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` isn't writable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `ReadOnlyFilesystem`
+    /// - `StorageFull`
+    /// - `InvalidFilename`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn write_lines(file_path: &str, lines: Array) -> Result<(), Box<EvalAltResult>> {
         let lines = lines.try_cast::<String>()?;
@@ -89,21 +149,23 @@ pub mod fs {
     /// Will create file and directory recursively if it doesn't exist
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` isn't writable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `ReadOnlyFilesystem`
+    /// - `StorageFull`
+    /// - `InvalidFilename`
+    /// - `InvalidUTF8`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn append(file_path: &str, content: &str) -> Result<(), Box<EvalAltResult>> {
-        let mut file = match std_fs::OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(file_path)
-        {
-            Ok(file) => file,
-            Err(err) => return Err(err.to_string().into()),
-        };
-
-        match file.write(content.as_bytes()) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err.to_string().into()),
-        }
+        let old_content = read(file_path)?;
+        write(file_path, &(old_content + content))
     }
 
     /// Appends an array of strings to a file, adding a newline after each string
@@ -111,6 +173,19 @@ pub mod fs {
     /// Will create file and directory recursively if it doesn't exist
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` isn't writable
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `ReadOnlyFilesystem`
+    /// - `StorageFull`
+    /// - `InvalidFilename`
+    /// - `InvalidUTF8`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn append_lines(file_path: &str, lines: Array) -> Result<(), Box<EvalAltResult>> {
         let lines = lines.try_cast::<String>()?;
@@ -121,25 +196,49 @@ pub mod fs {
     /// Removes a file or directory recursively
     /// > [!CAUTION]
     /// > Can throw exception if `path` can not be removed or does not exist
+    ///
+    /// <details>
+    /// <summary> exceptions </summary>
+    ///
+    /// - `filenotfound`
+    /// - `permissiondenied`
+    /// - `readonlyfilesystem`
+    /// - `invalidfilename`
+    /// - `otherfs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn remove(file_path: &str) -> Result<(), Box<EvalAltResult>> {
         let path = std_Path::new(file_path);
 
-        if path.is_file() {
-            return match std::fs::remove_file(path) {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err.to_string().into()),
-            };
-        }
+        let result = match (path.is_file(), path.is_dir()) {
+            (true, false) => std::fs::remove_file(path),
+            (false, true) => std::fs::remove_dir_all(path),
+            _ => {
+                return ScriptError::FsMalformedPath {
+                    path: file_path.into(),
+                }
+                .into()
+            }
+        };
 
-        if path.is_dir() {
-            return match std::fs::remove_dir_all(path) {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err.to_string().into()),
-            };
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::NotFound => ScriptError::FsFileNotFound {
+                    file_path: file_path.into(),
+                },
+                std::io::ErrorKind::PermissionDenied => ScriptError::FsPermissionDenied {
+                    path: file_path.into(),
+                    permission: "write".into(),
+                },
+                std::io::ErrorKind::ReadOnlyFilesystem => ScriptError::FsReadOnlyFilesystem,
+                std::io::ErrorKind::InvalidFilename => ScriptError::FsInvalidFilename {
+                    file_path: file_path.into(),
+                },
+                _ => ScriptError::FsError(err.to_string().into()),
+            }
+            .into(),
         }
-
-        Err("Provided path is neither a file nor a directory".into())
     }
 
     /// Creates a file
@@ -147,36 +246,80 @@ pub mod fs {
     /// If the parent directory does not exist, it is created recursively
     /// > [!CAUTION]
     /// > Can throw exception if `file_path` can not be created
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `PermissionDenied`
+    /// - `IsADirectory`
+    /// - `NotADirectory`
+    /// - `ReadOnlyFilesystem`
+    /// - `InvalidFilename`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn create(file_path: &str) -> Result<(), Box<EvalAltResult>> {
         let path = std_Path::new(file_path);
 
-        let result = match path.parent() {
-            Some(parent) => mkdir(parent.to_str().unwrap()),
-            None => Ok(()),
-        };
-
-        match result {
-            Ok(_) => {}
-            Err(err) => return Err(err.to_string().into()),
+        match path.parent() {
+            Some(parent) => mkdir(parent.to_str().unwrap())?,
+            None => {}
         };
 
         match std_fs::File::create(file_path) {
             Ok(_) => Ok(()),
-            Err(err) => Err(err.to_string().into()),
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::PermissionDenied => ScriptError::FsPermissionDenied {
+                    path: file_path.into(),
+                    permission: "write".into(),
+                },
+                std::io::ErrorKind::IsADirectory => ScriptError::FsIsADirectory {
+                    path: file_path.into(),
+                },
+                std::io::ErrorKind::NotADirectory => ScriptError::FsNotADirectory {
+                    path: file_path.into(),
+                },
+                std::io::ErrorKind::ReadOnlyFilesystem => ScriptError::FsReadOnlyFilesystem,
+                std::io::ErrorKind::StorageFull => ScriptError::FsStorageFull,
+                std::io::ErrorKind::InvalidFilename => ScriptError::FsInvalidFilename {
+                    file_path: file_path.into(),
+                },
+                _ => ScriptError::FsError(err.to_string().into()),
+            }
+            .into(),
         }
     }
 
     /// Creates a directory recursively
     /// > [!CAUTION]
     /// > Can throw exception if `dir_path` can not be created
+    ///
+    /// <details>
+    /// <summary> Exceptions </summary>
+    ///
+    /// - `PermissionDenied`
+    /// - `ReadOnlyFilesystem`
+    /// - `NotADirectory`
+    /// - `OtherFs`
+    /// </details>
     #[rhai_fn(return_raw)]
     pub fn mkdir(dir_path: &str) -> Result<(), Box<EvalAltResult>> {
         let path = std_Path::new(dir_path);
 
         match std_fs::create_dir_all(path) {
             Ok(_) => Ok(()),
-            Err(err) => Err(err.to_string().into()),
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::PermissionDenied => ScriptError::FsPermissionDenied {
+                    path: dir_path.into(),
+                    permission: "write".into(),
+                },
+                std::io::ErrorKind::ReadOnlyFilesystem => ScriptError::FsReadOnlyFilesystem,
+                std::io::ErrorKind::NotADirectory => ScriptError::FsNotADirectory {
+                    path: dir_path.into(),
+                },
+                _ => ScriptError::FsError(err.to_string()),
+            }
+            .into(),
         }
     }
 

--- a/talaria/src/stdlib/fs.rs
+++ b/talaria/src/stdlib/fs.rs
@@ -200,11 +200,11 @@ pub mod fs {
     /// <details>
     /// <summary> exceptions </summary>
     ///
-    /// - `filenotfound`
-    /// - `permissiondenied`
-    /// - `readonlyfilesystem`
-    /// - `invalidfilename`
-    /// - `otherfs`
+    /// - `FileNotFound`
+    /// - `PermissionDenied`
+    /// - `ReadOnlyFilesystem`
+    /// - `InvalidFilename`
+    /// - `OtherFs`
     /// </details>
     #[rhai_fn(return_raw)]
     pub fn remove(file_path: &str) -> Result<(), Box<EvalAltResult>> {

--- a/talaria/src/stdlib/sys.rs
+++ b/talaria/src/stdlib/sys.rs
@@ -6,7 +6,7 @@ use rhai::Module;
 #[export_module]
 pub mod sys {
 
-    use crate::stdlib::error::error::Error as script_error;
+    use crate::stdlib::error::error::ScriptError;
 
     use elevated_command; // 13.2 KiB (for elevation status)
     use std::{
@@ -58,7 +58,7 @@ pub mod sys {
     pub fn username() -> Result<String, Box<EvalAltResult>> {
         match whoami::fallible::username() {
             Ok(res) => Ok(res),
-            Err(error) => script_error::SysError(error.to_string()).into(),
+            Err(error) => ScriptError::SysError(error.to_string()).into(),
         }
     }
 
@@ -69,7 +69,7 @@ pub mod sys {
     pub fn hostname() -> Result<String, Box<EvalAltResult>> {
         match whoami::fallible::hostname() {
             Ok(res) => Ok(res),
-            Err(error) => script_error::SysError(error.to_string()).into(),
+            Err(error) => ScriptError::SysError(error.to_string()).into(),
         }
     }
 
@@ -109,7 +109,7 @@ pub mod sys {
             "windows" => process::Command::new("shutdown").args(vec!["/r"]).status(),
             _ => {
                 // Return when unsupported family
-                return script_error::SysUnsupportedError(
+                return ScriptError::SysUnsupportedError(
                     format!("Unsupported family: {}", consts::FAMILY).to_string(),
                 )
                 .into();
@@ -118,7 +118,7 @@ pub mod sys {
 
         match res {
             Ok(_exit_status) => Ok(()),
-            Err(error) => script_error::SysError(error.to_string()).into(),
+            Err(error) => ScriptError::SysError(error.to_string()).into(),
         }
     }
 
@@ -151,7 +151,7 @@ pub mod sys {
             "windows" => process::Command::new("shutdown").args(vec!["/s"]).status(),
             // Return when unsupported family
             _ => {
-                return script_error::SysUnsupportedError(
+                return ScriptError::SysUnsupportedError(
                     format!("Unsupported family: {}", consts::FAMILY).to_string(),
                 )
                 .into()
@@ -160,7 +160,7 @@ pub mod sys {
 
         match res {
             Ok(_exit_status) => Ok(()),
-            Err(error) => script_error::SysError(error.to_string()).into(),
+            Err(error) => ScriptError::SysError(error.to_string()).into(),
         }
     }
 
@@ -175,23 +175,23 @@ pub mod sys {
         if os_family() == "unix" {
             let proc_file = match std::fs::read_to_string("/proc/uptime") {
                 Ok(ok) => ok,
-                Err(error) => return script_error::SysError(error.to_string()).into(),
+                Err(error) => return ScriptError::SysError(error.to_string()).into(),
             };
 
             let time_vec = proc_file.trim().split(" ").collect::<Vec<&str>>();
 
             let uptime = match time_vec.len() == 2 {
                 true => time_vec[0].parse::<f32>(),
-                false => return script_error::SysError("uptime is malformed".to_string()).into(),
+                false => return ScriptError::SysError("uptime is malformed".to_string()).into(),
             };
 
             return match uptime {
                 Ok(ok) => Ok(ok),
-                Err(error) => script_error::SysError(error.to_string()).into(),
+                Err(error) => ScriptError::SysError(error.to_string()).into(),
             };
         }
 
-        script_error::SysUnsupportedError(
+        ScriptError::SysUnsupportedError(
             format!("Unsupported family: {}", consts::FAMILY).to_string(),
         )
         .into()


### PR DESCRIPTION
## New Error Type

Errors now can be described through the following syntax from within Rust:
```rust
pub enum ScriptError {
    #[strum(props(class = "fs", name = "OtherFs"), to_string = "{0}")]
    FsError(String),

    #[strum(
        props(class = "fs", name = "FileNotFound"),
        to_string = "could not find file at path: \"{file_path}\""
    )]
    FsFileNotFound { file_path: String },
    ....
  }
```
Additionally, `fs` has been migrated to specifically use these errors, and existing errors should continue to function in a second-class manor until manual work is done to port them over.

## Use from Rhai

The following getters were created to better take advantage of new context-rich errors:

### .class
Returns the class that this error belongs to:

```typescript
try {
  fs::remove("/"); // rm -rf :P
  sys::reboot();   // it's so joever for them!!!
}
catch (error) {
  switch(error.class) {
    "sys" => print("there was some error relating to the sys module"),
    "fs" => print("there was some error relating to the fs module"),
    _ => print("some other error occurred"),
  }
}
```

#### .name
Returns a deterministic string that can be matched upon to identify error type:
    
```typescript
try {
   let seed = fs::read("/home/coal/Important/MoneroSeed");
   print("all your monero is mine!!");
   print(seed);
}
catch (error) {
   switch(error.name) {
       "FileNotFound" => print("the monero seed does not exist"),
       "PermissionDenied" => print("no permission to read the monero seed"),
       "IsADirectory" => print("monero seed path is a directory"),
       "InvalidUTF8" => print("monero seed does not contain valid UTF-8"),
       "OtherFs" => print("some other filesystem error occurred:" + error.msg),
       _ => print("some other error occurred"),
   }
}
```
#### .msg
Returns message containing human readable description of the error:
```typescript
try {
   let homework = fs::read("/home/ruby/homework/calc1.mp4");
}
catch (error) {
   print(error.msg); // `file: "/home/ruby/homework/calc1.mp4" contains invalid utf-8`
}
```

#### .pretty
Returns a pretty print of the error:

```typescript
try {
   let homework = fs::read("/home/ruby/homework/calc1.mp4");
}
catch (error) {
   print(error.pretty); // `[fs] InvalidUTF8 - file: "/home/ruby/homework/calc1.mp4" contains invalid utf-8`
}
```

